### PR TITLE
Option to set name video downloaded

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,8 @@ import (
 )
 
 func main() {
-	hlsDL := hlsdl.New("https://bitdash-a.akamaihd.net/content/sintel/hls/video/1500kbit.m3u8", nil, "download", 64, true)
+	hlsDL := hlsdl.New("https://bitdash-a.akamaihd.net/content/sintel/hls/video/1500kbit.m3u8", nil, "download", 64, true, "")
+	
 	filepath, err := hlsDL.Download()
 	if err != nil {
 		panic(err)

--- a/cmd/hlsdl/main.go
+++ b/cmd/hlsdl/main.go
@@ -52,7 +52,7 @@ func cmdF(command *cobra.Command, args []string) error {
 }
 
 func downloadVodMovie(url string, dir string, workers int) error {
-	hlsDL := hlsdl.New(url, nil, dir, workers, true)
+	hlsDL := hlsdl.New(url, nil, dir, workers, true, "")
 	filepath, err := hlsDL.Download()
 	if err != nil {
 		return err

--- a/example/main.go
+++ b/example/main.go
@@ -7,7 +7,8 @@ import (
 )
 
 func main() {
-	hlsDL := hlsdl.New("https://bitdash-a.akamaihd.net/content/sintel/hls/video/1500kbit.m3u8", nil, "download", 64, true)
+	hlsDL := hlsdl.New("https://bitdash-a.akamaihd.net/content/sintel/hls/video/1500kbit.m3u8", nil, "download", 64, true, "")
+
 	filepath, err := hlsDL.Download()
 	if err != nil {
 		panic(err)

--- a/hlsdl.go
+++ b/hlsdl.go
@@ -46,7 +46,7 @@ type DownloadResult struct {
 
 func New(hlsURL string, headers map[string]string, dir string, workers int, enableBar bool, filename string) *HlsDl {
 	if filename == "" {
-		filename = getTimestamp()
+		filename = getFilename()
 	}
 
 	hlsdl := &HlsDl{
@@ -191,7 +191,7 @@ func (hlsDl *HlsDl) downloadSegments(segments []*Segment) error {
 func (hlsDl *HlsDl) join(dir string, segments []*Segment) (string, error) {
 	fmt.Println("Joining segments")
 
-	filepath := filepath.Join(dir, hlsDl.filename+".ts")
+	filepath := filepath.Join(dir, hlsDl.filename)
 
 	file, err := os.Create(filepath)
 	if err != nil {

--- a/hlsdl.go
+++ b/hlsdl.go
@@ -31,6 +31,7 @@ type HlsDl struct {
 	workers   int
 	bar       *pb.ProgressBar
 	enableBar bool
+	filename  string
 }
 
 type Segment struct {
@@ -43,7 +44,11 @@ type DownloadResult struct {
 	SeqId uint64
 }
 
-func New(hlsURL string, headers map[string]string, dir string, workers int, enableBar bool) *HlsDl {
+func New(hlsURL string, headers map[string]string, dir string, workers int, enableBar bool, filename string) *HlsDl {
+	if filename == "" {
+		filename = getTimestamp()
+	}
+
 	hlsdl := &HlsDl{
 		hlsURL:    hlsURL,
 		dir:       dir,
@@ -51,6 +56,7 @@ func New(hlsURL string, headers map[string]string, dir string, workers int, enab
 		workers:   workers,
 		enableBar: enableBar,
 		headers:   headers,
+		filename:  filename,
 	}
 
 	return hlsdl
@@ -185,7 +191,7 @@ func (hlsDl *HlsDl) downloadSegments(segments []*Segment) error {
 func (hlsDl *HlsDl) join(dir string, segments []*Segment) (string, error) {
 	fmt.Println("Joining segments")
 
-	filepath := filepath.Join(dir, getTimestamp()+".ts")
+	filepath := filepath.Join(dir, hlsDl.filename+".ts")
 
 	file, err := os.Create(filepath)
 	if err != nil {

--- a/hlsdl.go
+++ b/hlsdl.go
@@ -185,7 +185,7 @@ func (hlsDl *HlsDl) downloadSegments(segments []*Segment) error {
 func (hlsDl *HlsDl) join(dir string, segments []*Segment) (string, error) {
 	fmt.Println("Joining segments")
 
-	filepath := filepath.Join(dir, "video.ts")
+	filepath := filepath.Join(dir, getTimestamp()+".ts")
 
 	file, err := os.Create(filepath)
 	if err != nil {

--- a/hlsdl_test.go
+++ b/hlsdl_test.go
@@ -12,7 +12,7 @@ func TestDescrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", 2, false)
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", 2, false, "")
 	seg := segs[0]
 	seg.Path = fmt.Sprintf("%s/seg%d.ts", hlsDl.dir, seg.SeqId)
 	if err := hlsDl.downloadSegment(seg); err != nil {
@@ -26,7 +26,7 @@ func TestDescrypt(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
-	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", 2, false)
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", 2, false, "")
 	filepath, err := hlsDl.Download()
 	if err != nil {
 		t.Fatal(err)

--- a/util.go
+++ b/util.go
@@ -11,6 +11,6 @@ func printStruct(v interface{}) {
 	fmt.Println(string(d))
 }
 
-func getTimestamp() string {
-	return time.Now().Format("20060102150405")
+func getFilename() string {
+	return time.Now().Format("20060102150405") + ".ts"
 }

--- a/util.go
+++ b/util.go
@@ -3,9 +3,14 @@ package hlsdl
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 func printStruct(v interface{}) {
 	d, _ := json.Marshal(v)
 	fmt.Println(string(d))
+}
+
+func getTimestamp() string {
+	return time.Now().Format("20060102150405")
 }


### PR DESCRIPTION
- Add a new param to New function hlsdl in order to set a specific name of the video.ts  generated by the Download function.

- If the param is a empty string the filename is set to a timestamp value to prevent replace a file if you use the same folder for download.

- Update tests and README