### PR TITLE
Altered log from fmt to log to avoid issues

### DIFF
--- a/hlsdl.go
+++ b/hlsdl.go
@@ -189,7 +189,7 @@ func (hlsDl *HlsDl) downloadSegments(segments []*Segment) error {
 }
 
 func (hlsDl *HlsDl) join(dir string, segments []*Segment) (string, error) {
-	fmt.Println("Joining segments")
+	log.Println("Joining segments")
 
 	filepath := filepath.Join(dir, hlsDl.filename)
 


### PR DESCRIPTION
join @ hlds.go is printing to `fmt` instead of `log`, this can cause issues when using hlsdl as a package