### PR TITLE
use a common bytes.Buffer for decrypt

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -11,17 +11,17 @@ const (
 	syncByte = uint8(71) //0x47
 )
 
-func decryptAES128(crypted, key, iv []byte) ([]byte, error) {
+func decryptAES128(data, key, iv []byte) error {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	blockSize := block.BlockSize()
 	blockMode := cipher.NewCBCDecrypter(block, iv[:blockSize])
-	origData := make([]byte, len(crypted))
-	blockMode.CryptBlocks(origData, crypted)
-	origData = pkcs5UnPadding(origData)
-	return origData, nil
+	blockMode.CryptBlocks(data, data)
+	c := pkcs5UnPadding(data)
+	copy(data, c)
+	return nil
 }
 
 func pkcs5Padding(cipherText []byte, blockSize int) []byte {

--- a/hlsdl_test.go
+++ b/hlsdl_test.go
@@ -1,6 +1,7 @@
 package hlsdl
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"testing"
@@ -20,7 +21,9 @@ func TestDescrypt(t *testing.T) {
 	}
 	defer os.Remove(seg.Path)
 
-	if _, err := hlsDl.decrypt(seg); err != nil {
+	var buf bytes.Buffer
+
+	if _, err := hlsDl.decrypt(seg, &buf); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -31,5 +34,46 @@ func TestDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Fatalf("downloaded: %s", filepath)
 	os.RemoveAll(filepath)
+}
+
+func BenchmarkDecrypt(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	segs, err := parseHlsSegments("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", "", 2, false)
+	seg := segs[0]
+	seg.Path = fmt.Sprintf("%s/seg%d.ts", hlsDl.dir, seg.SeqId)
+	if err := hlsDl.downloadSegment(seg); err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(seg.Path)
+
+	var buf bytes.Buffer
+
+	if _, err := hlsDl.decrypt(seg, &buf); err != nil {
+		b.Fatal(err)
+	}
+
+	b.StopTimer()
+}
+
+func BenchmarkDownload(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", "", 2, false)
+	filepath, err := hlsDl.Download()
+	if err != nil {
+		b.Fatal(err)
+	}
+	os.RemoveAll(filepath)
+
+	b.StopTimer()
 }

--- a/recorder.go
+++ b/recorder.go
@@ -103,7 +103,7 @@ func (r *Recorder) downloadSegment(segment *Segment) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		data, err = decryptAES128(data, key, iv)
+		err = decryptAES128(data, key, iv)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The goal of this PR is to address #23 

we can make use of the fact that cipher.CryptBlocks() can operate on a single slice (instead of copying from src to dst it can operate in place)

from crypt.CryptBlocks() docs
> CryptBlocks encrypts or decrypts a number of blocks. The length of src must be a multiple of the block size. Dst and src must overlap entirely or not at all.

Added a test to benchmark memory usage (exact same as existing test but collecting pprof stats)

Before:
```
Dropped 41 nodes (cum <= 2.30MB)
Showing top 10 nodes out of 45
      flat  flat%   sum%        cum   cum%
  356.33MB 77.55% 77.55%   356.33MB 77.55%  io.ReadAll
   78.78MB 17.15% 94.69%    78.78MB 17.15%  github.com/canhlinh/hlsdl.decryptAES128
    6.66MB  1.45% 96.14%     6.66MB  1.45%  regexp.(*bitState).reset
    4.64MB  1.01% 97.15%     4.64MB  1.01%  io.copyBuffer
    3.50MB  0.76% 97.92%     3.50MB  0.76%  encoding/pem.Decode
    1.50MB  0.33% 98.24%     4.50MB  0.98%  crypto/x509.parseCertificate
         0     0% 98.24%    10.04MB  2.19%  crypto/tls.(*Conn).HandshakeContext
         0     0% 98.24%    10.04MB  2.19%  crypto/tls.(*Conn).clientHandshake
         0     0% 98.24%    10.04MB  2.19%  crypto/tls.(*Conn).handshakeContext
         0     0% 98.24%    10.04MB  2.19%  crypto/tls.(*Conn).verifyServerCertificate
```

After:
```
Showing nodes accounting for 18102.56kB, 85.49% of 21174.69kB total
Showing top 10 nodes out of 87
      flat  flat%   sum%        cum   cum%
 5281.67kB 24.94% 24.94%  5793.68kB 27.36%  io.copyBuffer
 4449.27kB 21.01% 45.96%  4449.27kB 21.01%  bytes.growSlice
 2717.01kB 12.83% 58.79%  2717.01kB 12.83%  os.ReadFile
 2562.51kB 12.10% 70.89%  2562.51kB 12.10%  encoding/pem.Decode
  528.17kB  2.49% 73.38%   528.17kB  2.49%  regexp.(*bitState).reset
  514.63kB  2.43% 75.81%   514.63kB  2.43%  crypto/tls.(*Conn).unmarshalHandshakeMessage
     513kB  2.42% 78.24%      513kB  2.42%  runtime.allocm
  512.17kB  2.42% 80.65%   512.17kB  2.42%  net/http.Header.Clone
  512.07kB  2.42% 83.07%   512.07kB  2.42%  net/url.parse
  512.06kB  2.42% 85.49%  1024.09kB  4.84%  os.(*File).readdir
```

Memory usage for the download test goes from 356MB -> 6MB

I was able to download the test file to my laptop and it appears to play ok, I am not sure if there is any other testing I can do